### PR TITLE
Update hyperlink to DCG basics doc page

### DIFF
--- a/index.html
+++ b/index.html
@@ -584,7 +584,7 @@ p(L, L) :- format('~s~n', [L]). % or do something fancier with L
 <h2>9 A Few Practical Hints</h2>
 <h3>9_1 basics.pl</h3>
 <p>A handy set of commonly used DCG primitives is available in
-<a href='http://www.swi-prolog.org/pldoc/doc/swi/library/dcg/basics.pl'>DCG Basics</a>. This lib has recently moved out of the http stuff, if you have an older version it may be elsewhere as <code>http/dcg_basics.pl</code>.</p>
+<a href='http://www.swi-prolog.org/pldoc/doc/_SWI_/library/dcg/basics.pl'>DCG Basics</a>. This lib has recently moved out of the http stuff, if you have an older version it may be elsewhere as <code>http/dcg_basics.pl</code>.</p>
 
 <div class='precode'><pre><code>:- use_module(library(dcg/basics)).
 </code></pre></div>


### PR DESCRIPTION
Was: http://www.swi-prolog.org/pldoc/doc/swi/library/dcg/basics.pl which is now an access denied error.

Update to a Google search result: http://www.swi-prolog.org/pldoc/doc/_SWI_/library/dcg/basics.pl which looks right enough to be useful.